### PR TITLE
simplify smoothstep maths

### DIFF
--- a/05/linear.frag
+++ b/05/linear.frag
@@ -7,9 +7,8 @@ uniform vec2 u_mouse;
 uniform float u_time;
 
 // Plot a line on Y using a value between 0.0-1.0
-float plot(vec2 st, float pct){
-  return  smoothstep( pct-0.02, pct, st.y) -
-          smoothstep( pct, pct+0.02, st.y);
+float plot(vec2 st) {    
+    return smoothstep(0.02, 0.0, abs(st.y - st.x));
 }
 
 void main() {
@@ -20,7 +19,7 @@ void main() {
     vec3 color = vec3(y);
 
     // Plot a line
-    float pct = plot(st,y);
+    float pct = plot(st);
     color = (1.0-pct)*color+pct*vec3(0.0,1.0,0.0);
 
 	gl_FragColor = vec4(color,1.0);


### PR DESCRIPTION
except if there is a pedagogical reason for using smoothstep twice, using it once seems simpler to understand